### PR TITLE
取消无意义默认值

### DIFF
--- a/lib/index.vue
+++ b/lib/index.vue
@@ -33,7 +33,7 @@ export default {
   props: {
     value: {
       type: String,
-      default: 'Vue + UEditor + v-model双向绑定'
+      default: ''
     },
     config: {
       type: Object,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ueditor-wrap",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Vue + UEditor + v-model双向绑定",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
编辑内容作为表单提交的时候，若绑定一个必须给表单赋值才能。比如，form是{}空对象，form.editor若没有赋值为编辑器内容就会出现无意义默认值。
感觉这种没意义的值还是不要留在正式项目上，容易出现bug。