### PR TITLE
增加一种内容更改的监听方式 可用props选择开启 默认50ms的防抖延迟 可以监听所有的用户输入更改 但是会带来一些额外的性能开销 可酌情开启

### DIFF
--- a/src/utils/Debounce.js
+++ b/src/utils/Debounce.js
@@ -1,0 +1,31 @@
+// 防抖函数
+export default function (func, wait, immediate) {
+  let timeout, args, context, timestamp, result
+
+  let later = function () {
+    let last = Date.now() - timestamp
+    if (last < wait && last >= 0) {
+      // 间隔太小，频率过多，继续延迟
+      timeout = setTimeout(later, wait - last)
+    } else {
+      timeout = null // 间隔够长，运行函数
+      if (!immediate) {
+        result = func.apply(context, args)
+        if (!timeout) context = args = null
+      }
+    }
+  }
+
+  return function (..._args) {
+    context = this
+    args = _args
+    timestamp = Date.now()
+    let callNow = immediate && !timeout
+    if (!timeout) timeout = setTimeout(later, wait)
+    if (callNow) {
+      result = func.apply(context, args)
+      context = args = null
+    }
+    return result
+  }
+}


### PR DESCRIPTION
其实这个东西我最主要的担心就是性能问题了 我自己测试了一下 直接往里面复制一个stackoverflow的页面进去 然后尝试修改 和 ueditor默认的进行比较 从肉眼上没有看出特别明显的性能差距（因为两者都挺卡的）

未来可以考虑加入一个性能基准测试
